### PR TITLE
Remove namespace definition in test manifest.

### DIFF
--- a/manifests/test-bgp-router.yaml
+++ b/manifests/test-bgp-router.yaml
@@ -1,9 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: metallb-system
-
----
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:


### PR DESCRIPTION
This stops accidental deletion of entire namespace when yaml is deleted.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

When the pre-patch yaml is deleted, it will delete the namespace of an operational cluster. Per convo w/ @danderson on Slack.