### PR TITLE
Remove Trailing YAML Section Delimiter

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -262,4 +262,3 @@ spec:
             - all
           readOnlyRootFilesystem: true
 
----


### PR DESCRIPTION
The trailing YAML section delimiter causes some YAML parsers to fail when parsing the file. This can be seen with the Ansible K8S module specifically:

https://github.com/ansible/ansible/issues/47081#issuecomment-451982493