### PR TITLE
Add ability to configure metrics host address.

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -53,6 +53,7 @@ type Config struct {
 	ProcessName   string
 	ConfigMapName string
 	NodeName      string
+	MetricsHost   string
 	MetricsPort   int
 	ReadEndpoints bool
 	Logger        log.Logger
@@ -218,7 +219,7 @@ func New(cfg *Config) (*Client, error) {
 
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		http.ListenAndServe(fmt.Sprintf(":%d", cfg.MetricsPort), nil)
+		http.ListenAndServe(fmt.Sprintf("%s:%d", cfg.MetricsHost, cfg.MetricsPort), nil)
 	}()
 
 	return c, nil

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -55,6 +55,7 @@ func main() {
 
 	var (
 		myNode = flag.String("node-name", "", "name of this Kubernetes node")
+		host   = flag.String("host", "", "HTTP host address")
 		port   = flag.Int("port", 80, "HTTP listening port")
 		config = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
 	)
@@ -64,6 +65,10 @@ func main() {
 
 	if *myNode == "" {
 		*myNode = os.Getenv("METALLB_NODE_NAME")
+	}
+
+	if *host == "" {
+		*host = os.Getenv("METALLB_HOST")
 	}
 
 	if *myNode == "" {
@@ -87,6 +92,7 @@ func main() {
 		NodeName:      *myNode,
 		Logger:        logger,
 
+		MetricsHost:   *host,
 		MetricsPort:   *port,
 		ReadEndpoints: true,
 


### PR DESCRIPTION
MetalLB exposes its metrics on every public endpoint, because the host port is used.
However it is desirable to reduce this to e.g. the internal node IP.

This PR adds the capability to specify the listener host address of the speaker metrics.

Both a flat `--host` and the environment variable `METALLB_HOST` can be used. The environment variable can then be automatically populated via:
```
        - name: METALLB_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
```

A public image we used for testing can be found here: https://hub.docker.com/r/trevex/speaker