### PR TITLE
add kustomization manifest

### DIFF
--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - metallb.yaml


### PR DESCRIPTION
Adding the kustomization file will allow people using [kustomize](https://github.com/kubernetes-sigs/kustomize/) to point directly to upstream repository.

```
resources:
  - github.com/remche/metallb//manifests?ref=v0.7.3
```

Notes :
- If we want to be able to use the `ref=v0.7.3` notation, you will have to rewrite tags. We can wait v0.8.1 though ;)
- I will write a small doc if PR is merged.