### PR TITLE
Add dual-stack support in the controller

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -166,12 +166,14 @@ func TestControllerMutation(t *testing.T) {
 			desc: "simple LoadBalancer",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					ClusterIP: "1.2.3.4",
+					Type:      "LoadBalancer",
 				},
 				Status: statusAssigned("1.2.3.0"),
 			},
@@ -181,12 +183,14 @@ func TestControllerMutation(t *testing.T) {
 			desc: "request specific IP",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{
+					ClusterIP:      "1.2.3.4",
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "1.2.3.1",
 				},
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
+					ClusterIP:      "1.2.3.4",
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "1.2.3.1",
 				},
@@ -200,6 +204,7 @@ func TestControllerMutation(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "please sir may I have an IP address thank you",
+					ClusterIP:      "1.2.3.4",
 				},
 			},
 			wantErr: true,
@@ -211,6 +216,7 @@ func TestControllerMutation(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "1.2.3.4",
+					ClusterIP:      "1.2.3.4",
 				},
 				Status: statusAssigned("1.2.3.1"),
 			},
@@ -218,6 +224,7 @@ func TestControllerMutation(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "1.2.3.4",
+					ClusterIP:      "1.2.3.4",
 				},
 			},
 			wantErr: true,
@@ -232,7 +239,8 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 			},
 			want: &v1.Service{
@@ -242,7 +250,8 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 				Status: statusAssigned("1.2.3.0"),
 			},
@@ -257,7 +266,8 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					ClusterIP: "1.2.3.4",
+					Type:      "LoadBalancer",
 				},
 				Status: statusAssigned("1.2.3.0"),
 			},
@@ -268,7 +278,8 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					ClusterIP: "1.2.3.4",
+					Type:      "LoadBalancer",
 				},
 				Status: statusAssigned("3.4.5.6"),
 			},
@@ -283,7 +294,8 @@ func TestControllerMutation(t *testing.T) {
 					},
 				},
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					ClusterIP: "1.2.3.4",
+					Type:      "LoadBalancer",
 				},
 			},
 			wantErr: true,
@@ -293,13 +305,15 @@ func TestControllerMutation(t *testing.T) {
 			desc: "invalid IP assigned",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 				Status: statusAssigned("2.3.4.5"),
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 				Status: statusAssigned("1.2.3.0"),
 			},
@@ -309,7 +323,8 @@ func TestControllerMutation(t *testing.T) {
 			desc: "invalid ingress state",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 				Status: v1.ServiceStatus{
 					LoadBalancer: v1.LoadBalancerStatus{
@@ -326,7 +341,8 @@ func TestControllerMutation(t *testing.T) {
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type: "LoadBalancer",
+					Type:      "LoadBalancer",
+					ClusterIP: "1.2.3.4",
 				},
 				Status: statusAssigned("1.2.3.0"),
 			},
@@ -355,12 +371,14 @@ func TestControllerMutation(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "3.4.5.6",
+					ClusterIP:      "1.2.3.4",
 				},
 			},
 			want: &v1.Service{
 				Spec: v1.ServiceSpec{
 					Type:           "LoadBalancer",
 					LoadBalancerIP: "3.4.5.6",
+					ClusterIP:      "1.2.3.4",
 				},
 				Status: statusAssigned("3.4.5.6"),
 			},
@@ -373,6 +391,7 @@ func TestControllerMutation(t *testing.T) {
 					Type:                  "LoadBalancer",
 					LoadBalancerIP:        "3.4.5.6",
 					ExternalTrafficPolicy: "Local",
+					ClusterIP:             "1.2.3.4",
 				},
 			},
 			want: &v1.Service{
@@ -380,6 +399,7 @@ func TestControllerMutation(t *testing.T) {
 					Type:                  "LoadBalancer",
 					LoadBalancerIP:        "3.4.5.6",
 					ExternalTrafficPolicy: "Local",
+					ClusterIP:             "1.2.3.4",
 				},
 				Status: statusAssigned("3.4.5.6"),
 			},
@@ -450,7 +470,8 @@ func TestControllerConfig(t *testing.T) {
 	l := log.NewNopLogger()
 	svc := &v1.Service{
 		Spec: v1.ServiceSpec{
-			Type: "LoadBalancer",
+			Type:      "LoadBalancer",
+			ClusterIP: "1.2.3.4",
 		},
 	}
 	if c.SetBalancer(l, "test", svc, nil) == k8s.SyncStateError {
@@ -556,7 +577,8 @@ func TestDeleteRecyclesIP(t *testing.T) {
 
 	svc1 := &v1.Service{
 		Spec: v1.ServiceSpec{
-			Type: "LoadBalancer",
+			Type:      "LoadBalancer",
+			ClusterIP: "1.2.3.4",
 		},
 	}
 	if c.SetBalancer(l, "test", svc1, nil) == k8s.SyncStateError {
@@ -575,7 +597,8 @@ func TestDeleteRecyclesIP(t *testing.T) {
 	// IP because we have none left.
 	svc2 := &v1.Service{
 		Spec: v1.ServiceSpec{
-			Type: "LoadBalancer",
+			Type:      "LoadBalancer",
+			ClusterIP: "1.2.3.4",
 		},
 	}
 	if c.SetBalancer(l, "test2", svc2, nil) == k8s.SyncStateError {

--- a/controller/service.go
+++ b/controller/service.go
@@ -41,7 +41,7 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 	// ipFamily to use.
 	clusterIP := net.ParseIP(svc.Spec.ClusterIP)
 	if clusterIP == nil {
-		l.Log("event", "clearAssignment", "reason", "notLoadBalancer", "msg", "No ClusterIP")
+		l.Log("event", "clearAssignment", "reason", "noClusterIP", "msg", "No ClusterIP")
 		c.clearServiceState(key, svc)
 		return true
 	}
@@ -146,7 +146,7 @@ func (c *controller) clearServiceState(key string, svc *v1.Service) {
 func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 	clusterIP := net.ParseIP(svc.Spec.ClusterIP)
 	if clusterIP == nil {
-		// (we should never get here)
+		// (we should never get here because the caller ensured that Spec.ClusterIP != nil)
 		return nil, fmt.Errorf("invalid ClusterIP [%s], can't determine family", svc.Spec.ClusterIP)
 	}
 	isIPv6 := clusterIP.To4() == nil

--- a/controller/service.go
+++ b/controller/service.go
@@ -157,6 +157,9 @@ func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 		if ip == nil {
 			return nil, fmt.Errorf("invalid spec.loadBalancerIP %q", svc.Spec.LoadBalancerIP)
 		}
+		if (ip.To4() == nil) != isIPv6 {
+			return nil, fmt.Errorf("invalid ip-family spec.loadBalancerIP %q", svc.Spec.LoadBalancerIP)
+		}
 		if err := c.ips.Assign(key, ip, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
 			return nil, err
 		}

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -319,6 +319,11 @@ func poolCount(p *config.Pool) int64 {
 	var total int64
 	for _, cidr := range p.CIDR {
 		o, b := cidr.Mask.Size()
+		if b-o >= 62 {
+			// An enormous ipv6 range is allocated which will never run out.
+			// Just return max to avoid any math errors.
+			return math.MaxInt64
+		}
 		sz := int64(math.Pow(2, float64(b-o)))
 
 		cur := ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr)})

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -211,7 +211,7 @@ func (a *Allocator) Unassign(svc string) bool {
 }
 
 // AllocateFromPool assigns an available IP from pool to service.
-func (a *Allocator) AllocateFromPool(svc, poolName string, ports []Port, sharingKey, backendKey string) (net.IP, error) {
+func (a *Allocator) AllocateFromPool(svc string, isIPv6 bool, poolName string, ports []Port, sharingKey, backendKey string) (net.IP, error) {
 	if alloc := a.allocated[svc]; alloc != nil {
 		if err := a.Assign(svc, alloc.ip, ports, sharingKey, backendKey); err != nil {
 			return nil, err
@@ -244,7 +244,7 @@ func (a *Allocator) AllocateFromPool(svc, poolName string, ports []Port, sharing
 }
 
 // Allocate assigns any available and assignable IP to service.
-func (a *Allocator) Allocate(svc string, ports []Port, sharingKey, backendKey string) (net.IP, error) {
+func (a *Allocator) Allocate(svc string, isIPv6 bool, ports []Port, sharingKey, backendKey string) (net.IP, error) {
 	if alloc := a.allocated[svc]; alloc != nil {
 		if err := a.Assign(svc, alloc.ip, ports, sharingKey, backendKey); err != nil {
 			return nil, err
@@ -256,7 +256,7 @@ func (a *Allocator) Allocate(svc string, ports []Port, sharingKey, backendKey st
 		if !a.pools[poolName].AutoAssign {
 			continue
 		}
-		if ip, err := a.AllocateFromPool(svc, poolName, ports, sharingKey, backendKey); err == nil {
+		if ip, err := a.AllocateFromPool(svc, isIPv6, poolName, ports, sharingKey, backendKey); err == nil {
 			return ip, nil
 		}
 	}

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -210,6 +210,10 @@ func (a *Allocator) Unassign(svc string) bool {
 	return true
 }
 
+func cidrIsIPv6(cidr *net.IPNet) bool {
+	return cidr.IP.To4() == nil
+}
+
 // AllocateFromPool assigns an available IP from pool to service.
 func (a *Allocator) AllocateFromPool(svc string, isIPv6 bool, poolName string, ports []Port, sharingKey, backendKey string) (net.IP, error) {
 	if alloc := a.allocated[svc]; alloc != nil {
@@ -225,6 +229,10 @@ func (a *Allocator) AllocateFromPool(svc string, isIPv6 bool, poolName string, p
 	}
 
 	for _, cidr := range pool.CIDR {
+		if cidrIsIPv6(cidr) != isIPv6 {
+			// Not the right ip-family
+			continue
+		}
 		c := ipaddr.NewCursor([]ipaddr.Prefix{*ipaddr.NewPrefix(cidr)})
 		for pos := c.First(); pos != nil; pos = c.Next() {
 			ip := pos.IP

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -308,7 +308,7 @@ func TestPoolAllocation(t *testing.T) {
 			alloc.Unassign(test.svc)
 			continue
 		}
-		ip, err := alloc.AllocateFromPool(test.svc, "test", test.ports, test.sharingKey, "")
+		ip, err := alloc.AllocateFromPool(test.svc, false, "test", test.ports, test.sharingKey, "")
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("%s: should have caused an error, but did not", test.desc)
@@ -325,7 +325,7 @@ func TestPoolAllocation(t *testing.T) {
 	}
 
 	alloc.Unassign("s5")
-	if _, err := alloc.AllocateFromPool("s5", "nonexistentpool", nil, "", ""); err == nil {
+	if _, err := alloc.AllocateFromPool("s5", false, "nonexistentpool", nil, "", ""); err == nil {
 		t.Error("Allocating from non-existent pool succeeded")
 	}
 }
@@ -415,7 +415,7 @@ func TestAllocation(t *testing.T) {
 			alloc.Unassign(test.svc)
 			continue
 		}
-		ip, err := alloc.Allocate(test.svc, test.ports, test.sharingKey, "")
+		ip, err := alloc.Allocate(test.svc, false, test.ports, test.sharingKey, "")
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("%s: should have caused an error, but did not", test.desc)
@@ -482,7 +482,7 @@ func TestBuggyIPs(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		ip, err := alloc.Allocate(test.svc, nil, "", "")
+		ip, err := alloc.Allocate(test.svc, false, nil, "", "")
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("#%d should have caused an error, but did not", i+1)
@@ -693,7 +693,7 @@ func TestAutoAssign(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		ip, err := alloc.Allocate(test.svc, nil, "", "")
+		ip, err := alloc.Allocate(test.svc, false, nil, "", "")
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("#%d should have caused an error, but did not", i+1)

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1,6 +1,7 @@
 package allocator
 
 import (
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -1205,6 +1206,15 @@ func TestPoolCount(t *testing.T) {
 				AvoidBuggyIPs: true,
 			},
 			want: 381,
+		},
+		{
+			desc: "BGP a BIG ipv6 range",
+			pool: &config.Pool{
+				Protocol:      config.BGP,
+				CIDR:          []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("2.3.4.128/25"), ipnet("1000::/64")},
+				AvoidBuggyIPs: true,
+			},
+			want: math.MaxInt64,
 		},
 	}
 


### PR DESCRIPTION
Fixes #464 

- [x] Add a `isIPv6` parameter to the pool Allocate functions
- [x] Check `isIPv6` and allocate from a pool with the correct family
- [x] Add test for the new function in `allocator_test.go`
- [x] Add controller tests
- [x] Investigate statistics and update if necessary https://github.com/danderson/metallb/pull/466#issuecomment-533507879

