### PR TITLE
Documentation: update provider list

### DIFF
--- a/website/content/installation/clouds.md
+++ b/website/content/installation/clouds.md
@@ -20,12 +20,13 @@ Azure          | No, use AKS
 DigitalOcean   | No, use DigitalOcean Kubernetes
 Google Cloud   | No, use GKE
 Hetzner        | No, [use alternatives]
-OVH            | No, [use alternatives]
+OVH            | Yes, when using a vRack
 OpenShift OCP  | Yes, see [OpenShift notes]
 OpenStack      | Yes, see [OpenStack notes]
 Packet         | Yes, see [Packet notes]
 Proxmox        | Yes
 VMWare         | Yes
+Vultr          | Yes
 
 [use alternatives]: #alternatives
 [OpenShift notes]: #metallb-on-openshift-ocp


### PR DESCRIPTION
I've been using MetalLB successfuly on [Vultr](https://www.vultr.com/) for the past few weeks. They [support BGP](https://www.vultr.com/features/bgp/) on all their virtual products in all locations. Setup was a breeze, it really "just worked".

I made amendments to the OVH listing as well, as I have been using MetalLB in Layer2 mode with a [vRack](https://www.ovh.com/world/solutions/vrack/) for quite some time. It requires that you purchase an IP block add it to the vRack, but after that you can use the IPs in an address pool with no problems so far.

Thanks for the hard work on MetalLB!