### PR TITLE
Fix url to pyinvoke


### DIFF
--- a/website/content/community/_index.md
+++ b/website/content/community/_index.md
@@ -109,7 +109,7 @@ To develop MetalLB, you'll need a couple of pieces of software:
 - [Docker](https://www.docker.com/docker-community), the container
   running system
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/), the Kubernetes commandline interface
-- [Invoke](https://pyinvoke.org) to drive the build system
+- [Invoke](https://www.pyinvoke.org) to drive the build system
 
 ## Building the code
 


### PR DESCRIPTION


Without this patch, people are pointed to a dead link.
This fixes it by simply adding the www. to the url, which is validly
pointing to pyinvoke docs.

